### PR TITLE
Integrated Removal of Session Keys ( not auto)

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,55 @@
+function addSessionListener(){
+	chrome.cookies.onChanged.addListener(function(changeInfo){
+	  	// listener that always wait for new cookies added and change them to session
+	  	if (!changeInfo.removed){ 
+	  		changeToASessionCookie(changeInfo.cookie);
+	  	}	
+	});
+}
+function removeSessionListener(){
+	chrome.cookies.onChanged.removeListener(function(){});
+}
+function changeToASessionCookie(currCookie){
+	var sessionCookie = copyAsSessionCookie(currCookie);
+	var removeCookie = copyAsRemoveCookie(currCookie);
+	chrome.cookies.remove(removeCookie);
+	chrome.cookies.set(sessionCookie);
+}
+function copyAsRemoveCookie(currCookie){
+  	var removeCookie = {};
+    removeCookie.url='http'+((currCookie.secure)?'s':'')+'://' + currCookie.domain + currCookie.path;
+	removeCookie.name = currCookie.name;
+	if (!isundefinednull(currCookie.storeId))
+		removeCookie.storeId = currCookie.storeId;
+	return removeCookie;
+}
+function copyAsSessionCookie(oldCookie){
+	var newCookie = {}; // no expirationDate so default as session
+	if (!isundefinednull(oldCookie.url))
+	   	newCookie.url = oldCookie.url ;
+	if (!isundefinednull(oldCookie.name))
+	   	newCookie.name = oldCookie.name;
+	if (!isundefinednull(oldCookie.value))
+	   	newCookie.value = oldCookie.value;
+	if (!isundefinednull(oldCookie.domain))
+		newCookie.domain = oldCookie.domain;
+	if (!isundefinednull(oldCookie.path))
+	   	newCookie.path = oldCookie.path;
+	if (!isundefinednull(oldCookie.secure))
+	   	newCookie.secure = oldCookie.secure;
+	if (!isundefinednull(oldCookie.httpOnly))
+	   	newCookie.httpOnly = oldCookie.httpOnly;
+	if (!isundefinednull(oldCookie.sameSite))
+		newCookie.sameSite = oldCookie.sameSite;
+	if (!isundefinednull(oldCookie.storeId))
+	   	newCookie.storeId = oldCookie.storeId;
+	newCookie.url='http'+((newCookie.secure)?'s':'')+'://' + newCookie.domain + newCookie.path;
+
+	return newCookie;
+}
+function isundefinednull(value){
+	  var undefinednull = false;
+	  if (value === undefined || value === null || value ==='undefined' || value==='null')
+	  	undefinednull = true;
+	  return undefinednull;
+  }

--- a/cookiemanager.html
+++ b/cookiemanager.html
@@ -19,8 +19,8 @@
   <script src="jquery.datetimepicker.full.min.js"></script>  
   <script type="text/javascript" src="cookiemanager.js"></script>  
   <link rel="stylesheet" href="jquery-ui.min.css">
-    <link rel="stylesheet" type="text/css" href="jquery.datetimepicker.min.css"/ >
-<link rel="stylesheet" type="text/css" href="cookiemanager.css" />
+  <link rel="stylesheet" type="text/css" href="jquery.datetimepicker.min.css"/ >
+  <link rel="stylesheet" type="text/css" href="cookiemanager.css" />
 </head>
 <body>
 <div id="tabs">
@@ -37,7 +37,9 @@
 		  <div id="autoRemove">
 			<button id="autoRemoveButton" value="OFF">OFF</button>
 		  </div>
-		  
+		  <div id="autoRemoveConfirm" title="Are You Sure?">
+		  	<p>All Cookies Will Be Set As Session Cookies.<br>This move is irreversible.</p>
+		  </div>
 		  <h3>Manual Remove</h3>
 		  <p><small>** compulsory</small></p>
 		  <div id="removeCookieManual">

--- a/manifest.json
+++ b/manifest.json
@@ -5,13 +5,13 @@
   "description": "The best extension for oliterating cookies!",
   "version": "1.0",
   "icons": { "16": "icon.png", "48": "icon.png", "128": "icon.png" },
-
   "browser_action": {
     "default_icon": "icon.png",
     "default_popup": "cookiemanager.html"
   },
   "permissions": [
     "tabs",
+    "storage",
     "activeTab",
 	"cookies",
 	"identity",
@@ -23,5 +23,9 @@
 	"matches": ["<all_urls>"],
 	"css":["jquery-ui.min.css","jquery.datetimepicker.min.css","cookiemanager.css"],
 	"js": ["jquery-1.12.3.min.js","jquery-ui.js","jquery.datetimepicker.full.min.js","cookiemanager.js"]
-  }]
+  }],
+  "background": {
+  	"scripts": ["background.js"],
+  	"persistent":true
+  	}
 }


### PR DESCRIPTION
Integrated Removal of Session Keys when session is open(run in foreground and background), not enabled(run in background only)
-Integrated dialog to confirm user's choice to set all cookies as session cookies
-Success: able to set all to session cookies when extension is open
-Integrated chrome.storage to remember user's options of whether to set all cookies as session cookies
-Still trying to enable AUTO removal 
 trying to integrate background.js to enable extension to run in background to listen for changed cookies
